### PR TITLE
Add minimal Documenter.jl setup

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v1
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs/ docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+CurveFit = "5a033b19-8c74-5913-a970-47c3779ef25c"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,25 @@
+using Documenter
+using CurveFit
+
+makedocs(;
+    sitename = "CurveFit.jl",
+    authors = "CurveFit Contributors",
+    modules = [CurveFit],
+    clean = true,
+    doctest = false,
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        canonical = "https://docs.sciml.ai/CurveFit/stable/",
+        assets = String[],
+    ),
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md",
+    ],
+)
+
+deploydocs(;
+    repo = "github.com/SciML/CurveFit.jl.git",
+    devbranch = "master",
+    push_preview = true,
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,39 @@
+# API
+
+```@index
+```
+
+## Problem Types
+
+```@docs
+CurveFitProblem
+NonlinearCurveFitProblem
+```
+
+## Algorithms
+
+```@docs
+LinearCurveFitAlgorithm
+PolynomialFitAlgorithm
+LogCurveFitAlgorithm
+PowerCurveFitAlgorithm
+ExpCurveFitAlgorithm
+RationalPolynomialFitAlgorithm
+KingCurveFitAlgorithm
+ModifiedKingCurveFitAlgorithm
+ExpSumFitAlgorithm
+```
+
+## Solutions
+
+```@docs
+CurveFitSolution
+```
+
+## Common Interface
+
+```@docs
+solve
+solve!
+init
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,27 @@
+# CurveFit.jl
+
+Linear, special function, and nonlinear curve fitting in Julia.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("CurveFit")
+```
+
+## Example
+
+```julia
+using CurveFit
+
+# Linear fitting
+x = 0:0.1:10
+y = @. 2.5 * x + 3.0 + 0.1 * randn()
+
+prob = CurveFitProblem(x, y, LinearCurveFitAlgorithm())
+sol = solve(prob)
+```
+
+## API
+
+See the [API](@ref) page for detailed documentation of all exported functions.


### PR DESCRIPTION
This PR adds a minimal barebones Documenter.jl setup following the style of NonlinearSolve.jl.

## Changes

- Added `docs/make.jl` with basic configuration
- Created minimal `docs/src/index.md` with installation and example
- Added `docs/src/api.md` listing all exported types and functions
- Added GitHub Actions workflow for documentation deployment

## Structure

```
docs/
├── Project.toml
├── make.jl
└── src/
    ├── index.md
    └── api.md
```

This provides the foundation for documentation that can be expanded later as needed.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>