### PR TITLE
test: Add regression tests for Issue #69 (noisy data fitting)

### DIFF
--- a/test/nonlinfit.jl
+++ b/test/nonlinfit.jl
@@ -108,3 +108,65 @@ end
         @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol=1.0e-7
     end
 end
+
+# Regression test for https://github.com/SciML/CurveFit.jl/issues/69
+@testitem "Issue #69: y ~ a/x with noisy data" begin
+    using SciMLBase
+
+    # Original issue: fitting y ~ a/x failed with NaN when data had noise
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    # Test case 1: Exact data (should work perfectly)
+    fn(a, x) = @. a[1] / x
+    y_exact = [1.0, 0.5, 1 / 3, 0.25, 0.2]
+    prob1 = NonlinearCurveFitProblem(fn, [0.1], x, y_exact)
+    sol1 = solve(prob1)
+
+    @test sol1.u[1] ≈ 1.0 atol = 1e-6
+    @test SciMLBase.successful_retcode(sol1.retcode)
+    @test !isnan(sol1.u[1])
+
+    # Test case 2: Data with tiny noise (previously failed with NaN)
+    y_noisy = [1.0, 0.5, 1 / 3 + 0.00000001, 0.25, 0.2]
+    prob2 = NonlinearCurveFitProblem(fn, [0.1], x, y_noisy)
+    sol2 = solve(prob2)
+
+    @test sol2.u[1] ≈ 1.0 atol = 1e-5
+    @test SciMLBase.successful_retcode(sol2.retcode)
+    @test !isnan(sol2.u[1])
+
+    # Test case 3: y ~ ax exact data
+    fn2(a, x) = @. a[1] * x
+    y2_exact = [1.0, 2.0, 3.0, 4.0, 5.0]
+    prob3 = NonlinearCurveFitProblem(fn2, [0.1], x, y2_exact)
+    sol3 = solve(prob3)
+
+    @test sol3.u[1] ≈ 1.0 atol = 1e-6
+    @test SciMLBase.successful_retcode(sol3.retcode)
+    @test !isnan(sol3.u[1])
+
+    # Test case 4: y ~ ax with tiny noise (previously failed with NaN)
+    y2_noisy = [1.0, 2.0, 3.000001, 4.0, 5.0]
+    prob4 = NonlinearCurveFitProblem(fn2, [0.1], x, y2_noisy)
+    sol4 = solve(prob4)
+
+    @test sol4.u[1] ≈ 1.0 atol = 1e-5
+    @test SciMLBase.successful_retcode(sol4.retcode)
+    @test !isnan(sol4.u[1])
+end
+
+@testitem "Issue #69: Robustness with larger noise" begin
+    using SciMLBase
+
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    # y ~ a/x with larger noise
+    fn(a, x) = @. a[1] / x
+    y_noisy = [1.0 + 0.01, 0.5 - 0.01, 1 / 3 + 0.01, 0.25, 0.2 - 0.005]
+    prob = NonlinearCurveFitProblem(fn, [0.1], x, y_noisy)
+    sol = solve(prob)
+
+    @test sol.u[1] ≈ 1.0 atol = 0.1  # Looser tolerance for noisy data
+    @test SciMLBase.successful_retcode(sol.retcode)
+    @test !isnan(sol.u[1])
+end


### PR DESCRIPTION
## Summary
- Adds regression tests for Issue #69 which reported that `nonlinear_fit` failed with NaN values when data had any noise
- The issue has been fixed in the v1.0.0 rewrite which uses NonlinearSolve.jl as the backend
- Tests verify that both exact and noisy data cases work correctly for `y ~ a/x` and `y ~ ax` models

## What was the issue?
In version 0.6.1, the following would fail:
```julia
nonlinear_fit(hcat([1,2,3,4,5], [1,1/2,1/3 + .00000001,1/4,1/5]), ((x,y), (a,)) -> a/x-y, [.1])
# ([NaN], false, 200)
```

With the new v1.0.0 API using NonlinearSolve.jl, this now works correctly:
```julia
fn(a, x) = @. a[1] / x
y_noisy = [1.0, 0.5, 1/3 + 0.00000001, 0.25, 0.2]
prob = NonlinearCurveFitProblem(fn, [0.1], x, y_noisy)
sol = solve(prob)
# sol.u[1] ≈ 1.0, retcode: StalledSuccess
```

## Test plan
- [x] All existing tests pass (241 tests)
- [x] New regression tests pass for Issue #69 scenarios

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)