### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-annotate_untyped_fields_with_any = false

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/CurveFit.jl
+++ b/src/CurveFit.jl
@@ -12,12 +12,12 @@ using LinearAlgebra: LinearAlgebra, eigvals!, diagm, qr!, lu!, ldiv!
 using LinearSolve: LinearSolve
 using NonlinearSolve: NonlinearSolve
 using SciMLBase: SciMLBase, AbstractNonlinearAlgorithm, AbstractLinearAlgorithm, ReturnCode,
-                 NonlinearFunction, LinearProblem, NonlinearLeastSquaresProblem
+    NonlinearFunction, LinearProblem, NonlinearLeastSquaresProblem
 using DifferentiationInterface: DifferentiationInterface
 using ADTypes: AutoForwardDiff
 using Distributions: TDist, quantile
 import StatsAPI: coef, residuals, predict, fitted, nobs, dof, dof_residual, rss, vcov, stderror,
-                 confint
+    confint
 
 # Abstract base class for fitting data
 abstract type AbstractApproxFit end
@@ -38,7 +38,7 @@ include("stats.jl")
 export CurveFitProblem, NonlinearCurveFitProblem
 
 export LinearCurveFitAlgorithm, LogCurveFitAlgorithm, PowerCurveFitAlgorithm,
-       ExpCurveFitAlgorithm, PolynomialFitAlgorithm
+    ExpCurveFitAlgorithm, PolynomialFitAlgorithm
 export RationalPolynomialFitAlgorithm
 export KingCurveFitAlgorithm, ModifiedKingCurveFitAlgorithm
 export ExpSumFitAlgorithm

--- a/src/common_interface.jl
+++ b/src/common_interface.jl
@@ -53,7 +53,7 @@ is_nonlinear_problem(prob::CurveFitProblem) = prob.nlfunc !== nothing
 
 function CurveFitProblem(x, y; nlfunc = nothing, u0 = nothing)
     if nlfunc === nothing
-        @assert ndims(x)==ndims(y)==1 "x and y must be 1-dimensional arrays for linear \
+        @assert ndims(x) == ndims(y) == 1 "x and y must be 1-dimensional arrays for linear \
                                        problems (`nlfunc` is `nothing`)"
     end
 
@@ -108,7 +108,7 @@ original space (can be specified by defining `InverseFunctions.inverse`).
 """
 function LinearCurveFitAlgorithm(;
         xfun = identity, yfun = identity, yfun_inverse = inverse(yfun)
-)
+    )
     return LinearCurveFitAlgorithm(xfun, yfun, yfun_inverse)
 end
 
@@ -326,14 +326,14 @@ function CommonSolve.init(prob::AbstractCurveFitProblem; kwargs...)
     return init(
         prob,
         is_nonlinear_problem(prob) ? __FallbackNonlinearFitAlgorithm(nothing) :
-        error("Default algorithm is not defined for linear problems");
+            error("Default algorithm is not defined for linear problems");
         kwargs...
     )
 end
 
 function CommonSolve.init(
         prob::AbstractCurveFitProblem, alg::AbstractNonlinearAlgorithm; kwargs...
-)
+    )
     @assert is_nonlinear_problem(prob) "Nonlinear algorithm can only be used with \
                                        nonlinear problems"
     return init(prob, __FallbackNonlinearFitAlgorithm(alg); kwargs...)

--- a/src/expsumfit.jl
+++ b/src/expsumfit.jl
@@ -32,9 +32,9 @@ end
 
 function __calc_integral_rules!(
         polyvals_factorized, integralvals::AbstractVector, n::nT, m::Integer
-) where {nT <: Integer}
-    @assert n≥1 "n=$n should be positive integer"
-    @assert n + m≤33 "m + n=$n + $m should be less than or equal to 33"
+    ) where {nT <: Integer}
+    @assert n ≥ 1 "n=$n should be positive integer"
+    @assert n + m ≤ 33 "m + n=$n + $m should be less than or equal to 33"
 
     # evaluate m-th order polynomial terms integrated cumulatively n-times
     num = m^(n - 1)
@@ -62,9 +62,9 @@ end
 function __cumulative_integrals!(
         Y::AbstractMatrix{T}, S::AbstractMatrix{T}, coeff::AbstractMatrix{T},
         x::AbstractVector{T}, y::AbstractVector{T}, n::Integer, m::Integer
-) where {T <: Real}
-    @assert n>0 "n=$n should be a positive integer"
-    @assert m>0 "m=$m should be a positive integer"
+    ) where {T <: Real}
+    @assert n > 0 "n=$n should be a positive integer"
+    @assert m > 0 "m=$m should be a positive integer"
 
     fill!(S, false)
 
@@ -98,7 +98,7 @@ end
 
 function __expsum_fill_X!(
         x::AbstractVector, λ::AbstractVector, X::AbstractMatrix, n::Integer
-)
+    )
     @inbounds for j in 1:n
         @simd ivdep for i in axes(X, 1)
             X[i, j] = exp(x[i] * λ[j])
@@ -111,7 +111,7 @@ end
 function __expsum_fill_Y!(
         Y::AbstractMatrix{T}, S::AbstractMatrix{T}, coeff::AbstractMatrix{T},
         x::AbstractVector{T}, y::AbstractVector{T}, n::Integer, m::Integer
-) where {T <: Real}
+    ) where {T <: Real}
     __cumulative_integrals!(Y, S, coeff, x, y, n, m)
 
     fill!(view(Y, 1, :), false)
@@ -148,7 +148,7 @@ end
 
 function CommonSolve.init(
         prob::CurveFitProblem, alg::ExpSumFitAlgorithm; kwargs...
-)
+    )
     @assert !is_nonlinear_problem(prob) "Exponential sum fitting only works with linear \
                                          problems"
 

--- a/src/king.jl
+++ b/src/king.jl
@@ -16,7 +16,7 @@ end
 
 function CommonSolve.init(
         prob::CurveFitProblem, alg::ModifiedKingCurveFitAlgorithm; kwargs...
-)
+    )
     @assert !is_nonlinear_problem(prob) "Modified King's law fitting doesn't work with \
                                          nlfunc specification."
 
@@ -61,7 +61,7 @@ function CommonSolve.solve!(cache::ModifiedKingFitCache)
         stack((cache.prob.x, cache.prob.y); dims = 1),
         nothing
     )
-    
+
     sol = solve(nonlinear_prob, __FallbackNonlinearFitAlgorithm(cache.alg.alg); cache.kwargs...)
     return CurveFitSolution(cache.alg, sol.u, sol.resid, cache.prob, sol.retcode, sol.original)
 end

--- a/src/linfit.jl
+++ b/src/linfit.jl
@@ -1,6 +1,6 @@
 function __linear_fit_internal(
         fnx::F1, x::AbstractArray{T1}, fny::F2, y::AbstractArray{T2}
-) where {F1, F2, T1, T2}
+    ) where {F1, F2, T1, T2}
     T = promote_type(T1, T2)
     m = length(x)
 
@@ -41,7 +41,7 @@ end
 function CommonSolve.init(prob::CurveFitProblem, alg::LinearCurveFitAlgorithm; kwargs...)
     @assert !is_nonlinear_problem(prob) "Linear curve fitting only works with linear \
                                          problems"
-    @assert prob.u0===nothing "Linear fit doesn't support initial guess (u0) \
+    @assert prob.u0 === nothing "Linear fit doesn't support initial guess (u0) \
                                specification"
 
     return GenericLinearFitCache(prob, kwargs, alg)
@@ -74,10 +74,10 @@ end
 
 function CommonSolve.init(
         prob::CurveFitProblem, alg::PolynomialFitAlgorithm; kwargs...
-)
+    )
     @assert !is_nonlinear_problem(prob) "Linear curve fitting only works with linear \
                                          problems"
-    @assert prob.u0===nothing "Polynomial fit doesn't support initial guess \
+    @assert prob.u0 === nothing "Polynomial fit doesn't support initial guess \
                                (u0) specification"
 
     vandermondepoly_cache = similar(prob.x, length(prob.x), alg.degree + 1)

--- a/src/nonlinfit.jl
+++ b/src/nonlinfit.jl
@@ -36,10 +36,10 @@ end
 
 function CommonSolve.init(
         prob::CurveFitProblem, alg::__FallbackNonlinearFitAlgorithm; kwargs...
-)
+    )
     @assert is_nonlinear_problem(prob) "Nonlinear curve fitting only works with nonlinear \
                                         problems"
-    @assert prob.u0!==nothing "Nonlinear curve fitting requires an initial guess (u0)"
+    @assert prob.u0 !== nothing "Nonlinear curve fitting requires an initial guess (u0)"
 
     return GenericNonlinearCurveFitCache(
         prob,

--- a/src/rationalfit.jl
+++ b/src/rationalfit.jl
@@ -56,14 +56,14 @@ end
 
 function CommonSolve.init(
         prob::CurveFitProblem, alg::RationalPolynomialFitAlgorithm; kwargs...
-)
+    )
     @assert !is_nonlinear_problem(prob) "Rational polynomial fitting doesn't work with \
                                          nlfunc specification."
 
     coeffs_length = alg.num_degree + alg.den_degree + 1
 
     if alg.alg isa AbstractLinearAlgorithm
-        @assert prob.u0===nothing "Rational polynomial fit doesn't support initial \
+        @assert prob.u0 === nothing "Rational polynomial fit doesn't support initial \
                                    guess (u0) specification"
 
         A = similar(prob.x, length(prob.x), coeffs_length)
@@ -109,7 +109,7 @@ function CommonSolve.solve!(cache::LinearRationalFitCache)
         # But StatsAPI expects y - p/q (nonlinear residual) or linearized?
         # Standard definition is y - y_pred.
         # So we should compute y - p(x)/q(x) using the fitted params.
-        
+
         # We need to construct the RationalPolynomial to eval it.
         # Helper function from rationalfit.jl isn't easily accessible inside solve! without alloc.
         # But we can reuse the logic from call:
@@ -142,11 +142,12 @@ function CommonSolve.solve!(cache::NonlinearRationalFitCache)
         cache.prob.x,
         cache.prob.y
     )
-    
+
     sol = solve(nonlinear_prob, __FallbackNonlinearFitAlgorithm(cache.alg.alg); cache.kwargs...)
-    
+
     return CurveFitSolution(
-        cache.alg, sol.u, sol.resid, cache.prob, sol.retcode, sol.original)
+        cache.alg, sol.u, sol.resid, cache.prob, sol.retcode, sol.original
+    )
 end
 
 function (sol::CurveFitSolution{<:RationalPolynomialFitAlgorithm})(x::Number)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -49,7 +49,7 @@ function jacobian(sol::CurveFitSolution{<:PolynomialFitAlgorithm})
     J = Matrix{eltype(x)}(undef, length(x), n + 1)
     J[:, 1] .= 1
     for i in 1:n
-        @. J[:, i + 1] = x^i 
+        @. J[:, i + 1] = x^i
     end
     return J
 end
@@ -59,41 +59,41 @@ function jacobian(sol::CurveFitSolution{<:RationalPolynomialFitAlgorithm})
     # requires Jacobian of the actual rational model y = p(x)/q(x).
     # Since prob.nlfunc might be nothing (for linear rational fit),
     # we define the model explicitly and assume u contains [num_coeffs; den_coeffs].
-    
+
     u = sol.u
     x = sol.prob.x
     num_deg = sol.alg.num_degree
     # den_deg = sol.alg.den_degree
-    
+
     # Model function f(u) -> predictions
     function model_rational(u_curr, x_val)
         # u is [num_coeffs..., den_coeffs...]
         # num has num_deg + 1 coeffs
-        # den has den_deg coeffs (implicit 1.0 constant term is handled in call, 
-        # but sol.u layout depends on implementation. 
+        # den has den_deg coeffs (implicit 1.0 constant term is handled in call,
+        # but sol.u layout depends on implementation.
         # RationalPolynomialFitAlgorithm (linear) usually assumes:
-        # constant term of q(x) is 1. 
+        # constant term of q(x) is 1.
         # Let's check call:
         # view(sol.u, 1:(sol.alg.num_degree + 1)) -> numerator
         # vcat(one, view(sol.u, (sol.alg.num_degree + 2):end)) -> denominator
-        
+
         num_c = view(u_curr, 1:(num_deg + 1))
         den_c_params = view(u_curr, (num_deg + 2):length(u_curr))
-        
+
         # We need to construct den with 1.0 at start, but 1.0 is constant.
         # evalpoly requires a vector.
         # Constructing [1.0, den_c_params...] with Duals might trigger allocation/conversion issues.
-        # Better to eval explicitly: 1.0 + evalpoly(x*x, den_c_params)*x ? 
+        # Better to eval explicitly: 1.0 + evalpoly(x*x, den_c_params)*x ?
         # No, evalpoly(x, [1, c...]) = 1 + c1*x + c2*x^2 ... = 1 + x * evalpoly(x, c)
-        
+
         val_num = evalpoly(x_val, num_c)
         val_den = one(eltype(u_curr)) + x_val * evalpoly(x_val, den_c_params)
         return val_num / val_den
     end
-    
+
     range = 1:length(x)
     f_pred = u_curr -> map(i -> model_rational(u_curr, x[i]), range)
-    
+
     return DifferentiationInterface.jacobian(f_pred, AutoForwardDiff(), u)
 end
 
@@ -101,10 +101,10 @@ function jacobian(sol::CurveFitSolution{<:ExpSumFitAlgorithm})
     # ExpSumFitAlgorithm solves y = k + sum(p_i * exp(lambda_i * x))
     # u is a ComponentArray/NamedArrayPartition with (k, p, λ)
     # prob.nlfunc is likely nothing.
-    
+
     u = sol.u
     x = sol.prob.x
-    
+
     # We must access u fields. Since u might be generic array or ComponentArray,
     # we need to handle access carefully matching the call implementation.
     # sol.u has fields :k, :p, :λ if NamedArrayPartition.
@@ -112,16 +112,16 @@ function jacobian(sol::CurveFitSolution{<:ExpSumFitAlgorithm})
     # We need to reshape/interpret u_curr based on sol.u structure.
     # But NamedArrayPartition structure isn't preserved in AD usually if passed as vector.
     # We know the sizes from sol.alg (n, m is irrelevant here).
-    
+
     n = sol.alg.n
     withconst = sol.alg.withconst
-    
+
     function model_expsum(u_curr, x_val)
         # Extract parameters from flat vector u_curr
         # Layout: k (if withconst), p (n), λ (n)
         # Check src/expsumfit.jl backing: (; k, p, λ)
         # NamedArrayPartition stores them sequentially.
-        
+
         idx = 1
         if withconst
             k = u_curr[idx]
@@ -130,22 +130,22 @@ function jacobian(sol::CurveFitSolution{<:ExpSumFitAlgorithm})
             k = zero(eltype(u_curr))
             # k doesn't advance idx
         end
-        
+
         # p is next n
         p = view(u_curr, idx:(idx + n - 1))
         idx += n
-        
+
         # λ is next n
         λ = view(u_curr, idx:(idx + n - 1))
-        
+
         # Computation: k + sum(p .* exp.(λ .* x))
         # Use sum generator to avoid allocation
         return k + sum(p[i] * exp(λ[i] * x_val) for i in 1:n)
     end
-    
+
     range = 1:length(x)
     f_pred = u_curr -> map(i -> model_expsum(u_curr, x[i]), range)
-    
+
     return DifferentiationInterface.jacobian(f_pred, AutoForwardDiff(), u)
 end
 
@@ -159,11 +159,11 @@ function jacobian(sol::CurveFitSolution{<:ModifiedKingCurveFitAlgorithm})
     # The "residual" is (Prediction - Observation).
     # Observation is x^2. Prediction is A + B*y^n.
     # We need Jacobian of Prediction w.r.t parameters.
-    
+
     u = sol.u
     x = sol.prob.x # E
     y = sol.prob.y # U
-    
+
     # Check if y is valid (it should be)
     @assert y !== nothing "Modified King fit requires valid `y` data (Velocity)"
 
@@ -176,7 +176,7 @@ function jacobian(sol::CurveFitSolution{<:ModifiedKingCurveFitAlgorithm})
 
     range = 1:length(y)
     f_pred = u_curr -> map(i -> model_mod_king(u_curr, y[i]), range)
-    
+
     return DifferentiationInterface.jacobian(f_pred, AutoForwardDiff(), u)
 end
 
@@ -187,11 +187,11 @@ function jacobian(sol::CurveFitSolution)
     # This is equivalent to d(model)/du since y is constant
     u = sol.u
     x = sol.prob.x
-    
+
     # We need a function f(u) -> residuals
     # CurveFitProblem has nlfunc which is f(u, x) or f(resid, u, x)
     # We construct a wrapper for DifferentiationInterface
-    
+
     if SciMLBase.isinplace(sol.prob)
         # In-place: f(resid, u, x)
         f_resid! = (resid, u_curr) -> sol.prob.nlfunc(resid, u_curr, x)
@@ -212,55 +212,53 @@ function isconverged(sol::CurveFitSolution)
 end
 
 
-
 function vcov(sol::CurveFitSolution)
     J = jacobian(sol)
-    
+
     # Compute the covariance matrix from the QR decomposition
     # This is numerically more stable than inv(J'J)
     Q, R = LinearAlgebra.qr(J)
-    
+
     # Check for rank deficiency or other issues?
-    # LinearAlgebra.qr usually handles full rank. 
+    # LinearAlgebra.qr usually handles full rank.
     # R is upper triangular. Rinv = inv(R)
-    
+
     # Ideally checking rank(R) would be good, but assuming J is full rank for now.
-    
+
     Rinv = inv(R)
     covar = Rinv * Rinv' * mse(sol)
-    
+
     return covar
 end
 
 
-
-function stderror(sol::CurveFitSolution; rtol::Real=NaN, atol::Real=0)
+function stderror(sol::CurveFitSolution; rtol::Real = NaN, atol::Real = 0)
     covar = vcov(sol)
     vars = LinearAlgebra.diag(covar)
-    
+
     # Safety check from LsqFit.jl
     vratio = minimum(vars) / maximum(vars)
     if !isapprox(
-        vratio,
-        0.0,
-        atol=atol,
-        rtol=isnan(rtol) ? Base.rtoldefault(vratio, 0.0, 0) : rtol,
-    ) && vratio < 0.0
+            vratio,
+            0.0,
+            atol = atol,
+            rtol = isnan(rtol) ? Base.rtoldefault(vratio, 0.0, 0) : rtol,
+        ) && vratio < 0.0
         error("Covariance matrix is negative for atol=$atol and rtol=$rtol")
     end
-    
+
     return sqrt.(abs.(vars))
 end
 
 
-function margin_error(sol::CurveFitSolution, alpha=0.05; rtol::Real=NaN, atol::Real=0)
-    std_errors = stderror(sol; rtol=rtol, atol=atol)
+function margin_error(sol::CurveFitSolution, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
+    std_errors = stderror(sol; rtol = rtol, atol = atol)
     dist = TDist(dof(sol))
     critical_values = quantile(dist, 1 - alpha / 2)
     return std_errors * critical_values
 end
 
-function confint(sol::CurveFitSolution; level=0.95, rtol::Real=NaN, atol::Real=0)
-    margin_of_errors = margin_error(sol, 1 - level; rtol=rtol, atol=atol)
+function confint(sol::CurveFitSolution; level = 0.95, rtol::Real = NaN, atol::Real = 0)
+    margin_of_errors = margin_error(sol, 1 - level; rtol = rtol, atol = atol)
     return collect(zip(coef(sol) .- margin_of_errors, coef(sol) .+ margin_of_errors))
 end

--- a/test/expsumfit.jl
+++ b/test/expsumfit.jl
@@ -4,17 +4,17 @@
 
     # Simpson's first (1/3) rule
     @test CurveFit.__calc_integral_rules(Rational{Int64}, 1:1; m = 2) ==
-          [1 // 3 4 // 3 1 // 3]
+        [1 // 3 4 // 3 1 // 3]
     @test CurveFit.__calc_integral_rules(Rational{Int64}, 2:2; m = 2) ==
-          [2 // 3 4 // 3 0 // 1]
+        [2 // 3 4 // 3 0 // 1]
     @test CurveFit.__calc_integral_rules(Rational{Int64}, 3:3; m = 2) ==
-          [3 // 5 4 // 5 -1 // 15]
+        [3 // 5 4 // 5 -1 // 15]
 
     # Simpson's second (3/8) rule
     @test CurveFit.__calc_integral_rules(Rational{Int64}, 1:1; m = 3) ==
-          [3 // 8 9 // 8 9 // 8 3 // 8]
+        [3 // 8 9 // 8 9 // 8 3 // 8]
     @test CurveFit.__calc_integral_rules(Rational{Int64}, 2:2; m = 3) ==
-          [39 // 40 27 // 10 27 // 40 3 // 20]
+        [39 // 40 27 // 10 27 // 40 3 // 20]
 end
 
 @testitem "ExpSumFit: Cumulative integrals" begin
@@ -22,15 +22,19 @@ end
 
     x = collect(0:0.4:10)
     y = @. 1 + sin(x)
-    cumints_analytic = @. [(x + 1 - cos(x)) (1 / 2 * x^2 + x - sin(x)) (1 / 6 * x^3 +
-                                                                        x^2 / 2 +
-                                                                        cos(x) - 1) (1 /
-                                                                                     24 *
-                                                                                     x^4 +
-                                                                                     x^3 /
-                                                                                     6 +
-                                                                                     sin(x) -
-                                                                                     x)]
+    cumints_analytic = @. [(x + 1 - cos(x)) (1 / 2 * x^2 + x - sin(x)) (
+        1 / 6 * x^3 +
+            x^2 / 2 +
+            cos(x) - 1
+    ) (
+        1 /
+            24 *
+            x^4 +
+            x^3 /
+            6 +
+            sin(x) -
+            x
+    )]
 
     @testset "m = 1 & n = 4" begin
         coeffs = CurveFit.__calc_integral_rules(Float64, 1:4; m = 1)
@@ -43,10 +47,10 @@ end
 
         CurveFit.__cumulative_integrals!(Y, S, coeffs, x, y, 4, 1)
 
-        @test cumints_analytic[:, 1]≈Y[:, 1] rtol=3e-3
-        @test cumints_analytic[:, 2]≈Y[:, 2] rtol=3e-3
-        @test cumints_analytic[:, 3]≈Y[:, 3] rtol=4e-3
-        @test cumints_analytic[:, 4]≈Y[:, 4] rtol=4e-3
+        @test cumints_analytic[:, 1] ≈ Y[:, 1] rtol = 3.0e-3
+        @test cumints_analytic[:, 2] ≈ Y[:, 2] rtol = 3.0e-3
+        @test cumints_analytic[:, 3] ≈ Y[:, 3] rtol = 4.0e-3
+        @test cumints_analytic[:, 4] ≈ Y[:, 4] rtol = 4.0e-3
     end
 
     @testset "m = 2 & n = 4" begin
@@ -60,20 +64,22 @@ end
 
         CurveFit.__cumulative_integrals!(Y, S, coeffs, x, y, 4, 2)
 
-        @test cumints_analytic[1:2:end, 1]≈Y[:, 1] rtol=3e-5
-        @test cumints_analytic[1:2:end, 2]≈Y[:, 2] rtol=4e-5
-        @test cumints_analytic[1:2:end, 3]≈Y[:, 3] rtol=5e-5
-        @test cumints_analytic[1:2:end, 4]≈Y[:, 4] rtol=6e-5
+        @test cumints_analytic[1:2:end, 1] ≈ Y[:, 1] rtol = 3.0e-5
+        @test cumints_analytic[1:2:end, 2] ≈ Y[:, 2] rtol = 4.0e-5
+        @test cumints_analytic[1:2:end, 3] ≈ Y[:, 3] rtol = 5.0e-5
+        @test cumints_analytic[1:2:end, 4] ≈ Y[:, 4] rtol = 6.0e-5
     end
 
     x = collect(range(0, stop = 2, length = 13))
     y = @. exp(x)
-    cumints_analytic = @. [(exp(x) - 1) (exp(x) - 1 - x) (exp(x) - 1 - x - x^2 / 2) (exp(x) -
-                                                                                     1 - x -
-                                                                                     x^2 /
-                                                                                     2 -
-                                                                                     x^3 /
-                                                                                     6)]
+    cumints_analytic = @. [(exp(x) - 1) (exp(x) - 1 - x) (exp(x) - 1 - x - x^2 / 2) (
+        exp(x) -
+            1 - x -
+            x^2 /
+            2 -
+            x^3 /
+            6
+    )]
 
     @testset "m = 2 & n = 4" begin
         coeffs = CurveFit.__calc_integral_rules(Float64, 1:4; m = 2)
@@ -86,10 +92,10 @@ end
 
         CurveFit.__cumulative_integrals!(Y, S, coeffs, x, y, 4, 2)
 
-        @test cumints_analytic[1:2:end, 1]≈Y[:, 1] rtol=5e-6
-        @test cumints_analytic[1:2:end, 2]≈Y[:, 2] rtol=3e-5
-        @test cumints_analytic[1:2:end, 3]≈Y[:, 3] rtol=3e-5
-        @test cumints_analytic[1:2:end, 4]≈Y[:, 4] rtol=4e-5
+        @test cumints_analytic[1:2:end, 1] ≈ Y[:, 1] rtol = 5.0e-6
+        @test cumints_analytic[1:2:end, 2] ≈ Y[:, 2] rtol = 3.0e-5
+        @test cumints_analytic[1:2:end, 3] ≈ Y[:, 3] rtol = 3.0e-5
+        @test cumints_analytic[1:2:end, 4] ≈ Y[:, 4] rtol = 4.0e-5
     end
 end
 
@@ -100,25 +106,25 @@ end
     prob = CurveFitProblem(x, y)
     sol = solve(prob, ExpSumFitAlgorithm(; n = 4, m = 2, withconst = false))
 
-    @test sol.u.λ≈[-3, -2, 0.15, 0.5] rtol=1e-3
-    @test sol.u.p≈[4, 2, -3, 5] rtol=1e-2
+    @test sol.u.λ ≈ [-3, -2, 0.15, 0.5] rtol = 1.0e-3
+    @test sol.u.p ≈ [4, 2, -3, 5] rtol = 1.0e-2
 
     y = @. -1 + 5 * exp(0.5 * x) + 4 * exp(-3 * x) + 2 * exp(-2 * x)
 
     prob = CurveFitProblem(x, y)
     sol = solve(prob, ExpSumFitAlgorithm(; n = 3, m = 1, withconst = true))
 
-    @test sol.u.λ≈[-3, -2, 0.5] rtol=7e-4
-    @test sol.u.p≈[4, 2, 5] rtol=3e-3
-    @test sol.u.k[]≈-1 rtol=2e-3
+    @test sol.u.λ ≈ [-3, -2, 0.5] rtol = 7.0e-4
+    @test sol.u.p ≈ [4, 2, 5] rtol = 3.0e-3
+    @test sol.u.k[] ≈ -1 rtol = 2.0e-3
 
     sol = solve(prob, ExpSumFitAlgorithm(; n = 3, m = 2, withconst = true))
-    @test sol.u.λ≈[-3, -2, 0.5] rtol=5e-7
-    @test sol.u.p≈[4, 2, 5] rtol=9e-6
-    @test sol.u.k[]≈-1 rtol=2e-6
+    @test sol.u.λ ≈ [-3, -2, 0.5] rtol = 5.0e-7
+    @test sol.u.p ≈ [4, 2, 5] rtol = 9.0e-6
+    @test sol.u.k[] ≈ -1 rtol = 2.0e-6
 
     # decay curve
-    fs, ts, ω₀, τ = 20e3, 0.2, 6283.2, 0.0322
+    fs, ts, ω₀, τ = 20.0e3, 0.2, 6283.2, 0.0322
     t = range(0, step = 1 / fs, stop = ts)
     y = @. 1.23 * exp(-t / τ) * cos(ω₀ * t)
 
@@ -126,11 +132,11 @@ end
     sol = solve(prob, ExpSumFitAlgorithm(; n = 2, m = 2))
 
     y_fit = sol(t)
-    @test isapprox(y, y_fit, rtol = 9e-3)
+    @test isapprox(y, y_fit, rtol = 9.0e-3)
     sol = solve(prob, ExpSumFitAlgorithm(; n = 2, m = 4))
     y_fit = sol(t)
-    @test isapprox(y, y_fit, rtol = 6e-4)
+    @test isapprox(y, y_fit, rtol = 6.0e-4)
     sol = solve(prob, ExpSumFitAlgorithm(; n = 2, m = 6))
     y_fit = sol(t)
-    @test isapprox(y, y_fit, rtol = 5e-5)
+    @test isapprox(y, y_fit, rtol = 5.0e-5)
 end

--- a/test/king.jl
+++ b/test/king.jl
@@ -27,20 +27,20 @@ end
     fn(E) = ((E .^ 2 .- A) ./ B) .^ (1 ./ n)
 
     algs = [
-    # TODO: broken due to https://github.com/SciML/NonlinearSolve.jl/issues/504
-    # nothing,
-        LevenbergMarquardt()
+        # TODO: broken due to https://github.com/SciML/NonlinearSolve.jl/issues/504
+        # nothing,
+        LevenbergMarquardt(),
     ]
     u0s = [nothing, fill(1.0, 3)]
     for alg in algs, u0 in u0s
         prob = CurveFitProblem(E, U; u0 = u0)
         sol = solve(prob, ModifiedKingCurveFitAlgorithm(alg))
 
-        @test sol.u≈[A, B, n] atol=1.0e-8
+        @test sol.u ≈ [A, B, n] atol = 1.0e-8
         @test SciMLBase.successful_retcode(sol.retcode)
 
         @testset for val in range(minimum(E), stop = maximum(E), length = 10)
-            @test sol(val)≈fn(val) atol=1.0e-8
+            @test sol(val) ≈ fn(val) atol = 1.0e-8
         end
     end
 end

--- a/test/linfit.jl
+++ b/test/linfit.jl
@@ -81,40 +81,41 @@ end
     @test sol.u[2] ≈ 2.0
     @test sol.u[3] ≈ 3.0
     @test sol.u[4] ≈ 0.5
-    @test sol.u[5]≈0.0 atol=1e-8
+    @test sol.u[5] ≈ 0.0 atol = 1.0e-8
 
     @testset for val in (0.0, 1.5, 4.5, 10.0)
         @test sol(val) ≈ fn(val)
     end
 
     @testset "ill-conditioned" begin
-        true_coeffs = [80.0, -5e-18, -7e-20, -1e-36]
-        x1 = 1e10 .* (0:0.1:5)
+        true_coeffs = [80.0, -5.0e-18, -7.0e-20, -1.0e-36]
+        x1 = 1.0e10 .* (0:0.1:5)
         y1 = evalpoly.(x1, (true_coeffs,))
 
         prob = CurveFitProblem(x1, y1)
         sol = solve(prob, PolynomialFitAlgorithm(3, QRFactorization()))
 
-        @test sol.u[1]≈true_coeffs[1] rtol=1e-5
-        @test sol.u[2]≈true_coeffs[2] rtol=1e-5
-        @test sol.u[3]≈true_coeffs[3] rtol=1e-5
-        @test sol.u[4]≈true_coeffs[4] rtol=1e-5
+        @test sol.u[1] ≈ true_coeffs[1] rtol = 1.0e-5
+        @test sol.u[2] ≈ true_coeffs[2] rtol = 1.0e-5
+        @test sol.u[3] ≈ true_coeffs[3] rtol = 1.0e-5
+        @test sol.u[4] ≈ true_coeffs[4] rtol = 1.0e-5
 
         @testset for val in (0.0, 1.5, 4.5, 10.0)
             @test sol(val) ≈ evalpoly(val, true_coeffs)
         end
 
-        sol = solve(prob,
+        sol = solve(
+            prob,
             PolynomialFitAlgorithm(3);
             assumptions = OperatorAssumptions(
                 false; condition = OperatorCondition.VeryIllConditioned
             )
         )
 
-        @test sol.u[1]≈true_coeffs[1] rtol=1e-5
-        @test sol.u[2]≈true_coeffs[2] rtol=1e-5
-        @test sol.u[3]≈true_coeffs[3] rtol=1e-5
-        @test sol.u[4]≈true_coeffs[4] rtol=1e-5
+        @test sol.u[1] ≈ true_coeffs[1] rtol = 1.0e-5
+        @test sol.u[2] ≈ true_coeffs[2] rtol = 1.0e-5
+        @test sol.u[3] ≈ true_coeffs[3] rtol = 1.0e-5
+        @test sol.u[4] ≈ true_coeffs[4] rtol = 1.0e-5
 
         @testset for val in (0.0, 1.5, 4.5, 10.0)
             @test sol(val) ≈ evalpoly(val, true_coeffs)

--- a/test/nonlinfit.jl
+++ b/test/nonlinfit.jl
@@ -55,11 +55,11 @@ end
     prob = NonlinearCurveFitProblem(fn, [0.5, 0.5, 0.5], X)
     sol = solve(prob)
 
-    @test sol.u ≈ a0 atol=1.0e-7
+    @test sol.u ≈ a0 atol = 1.0e-7
     @test SciMLBase.successful_retcode(sol.retcode)
 
     @testset for val in (0.0, 1.5, 4.5, 10.0)
-        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol=1.0e-7
+        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol = 1.0e-7
     end
 end
 
@@ -80,11 +80,11 @@ end
     prob = NonlinearCurveFitProblem(fn, [0.5, 0.5, 0.5], X)
     sol = solve(prob)
 
-    @test sol.u ≈ a0 atol=1.0e-7
+    @test sol.u ≈ a0 atol = 1.0e-7
     @test SciMLBase.successful_retcode(sol.retcode)
 
     @testset for val in (0.0, 1.5, 4.5, 10.0)
-        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol=1.0e-7
+        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol = 1.0e-7
     end
 end
 
@@ -101,11 +101,11 @@ end
     prob = NonlinearCurveFitProblem(fn, [0.5, 0.5, 0.5], X)
     sol = solve(prob)
 
-    @test sol.u ≈ a0 atol=1.0e-7
+    @test sol.u ≈ a0 atol = 1.0e-7
     @test SciMLBase.successful_retcode(sol.retcode)
 
     @testset for val in range(minimum(E), stop = maximum(E), length = 10)
-        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol=1.0e-7
+        @test sol([val 0.0])[1] ≈ fn(a0, [val 0.0])[1] atol = 1.0e-7
     end
 end
 
@@ -122,7 +122,7 @@ end
     prob1 = NonlinearCurveFitProblem(fn, [0.1], x, y_exact)
     sol1 = solve(prob1)
 
-    @test sol1.u[1] ≈ 1.0 atol = 1e-6
+    @test sol1.u[1] ≈ 1.0 atol = 1.0e-6
     @test SciMLBase.successful_retcode(sol1.retcode)
     @test !isnan(sol1.u[1])
 
@@ -131,7 +131,7 @@ end
     prob2 = NonlinearCurveFitProblem(fn, [0.1], x, y_noisy)
     sol2 = solve(prob2)
 
-    @test sol2.u[1] ≈ 1.0 atol = 1e-5
+    @test sol2.u[1] ≈ 1.0 atol = 1.0e-5
     @test SciMLBase.successful_retcode(sol2.retcode)
     @test !isnan(sol2.u[1])
 
@@ -141,7 +141,7 @@ end
     prob3 = NonlinearCurveFitProblem(fn2, [0.1], x, y2_exact)
     sol3 = solve(prob3)
 
-    @test sol3.u[1] ≈ 1.0 atol = 1e-6
+    @test sol3.u[1] ≈ 1.0 atol = 1.0e-6
     @test SciMLBase.successful_retcode(sol3.retcode)
     @test !isnan(sol3.u[1])
 
@@ -150,7 +150,7 @@ end
     prob4 = NonlinearCurveFitProblem(fn2, [0.1], x, y2_noisy)
     sol4 = solve(prob4)
 
-    @test sol4.u[1] ≈ 1.0 atol = 1e-5
+    @test sol4.u[1] ≈ 1.0 atol = 1.0e-5
     @test SciMLBase.successful_retcode(sol4.retcode)
     @test !isnan(sol4.u[1])
 end

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua tests" tags=[:nopre] begin
+@testitem "Aqua tests" tags = [:nopre] begin
     using Aqua
     Aqua.test_all(CurveFit)
 end

--- a/test/rationalfit.jl
+++ b/test/rationalfit.jl
@@ -8,10 +8,10 @@
     prob = CurveFitProblem(x, y)
     sol = solve(prob, RationalPolynomialFitAlgorithm(2, 3, QRFactorization(ColumnNorm())))
 
-    @test sol.u≈[1.0, 0.0, -2.0, 2.0, 3.0, 0.0] atol=1.0e-8
+    @test sol.u ≈ [1.0, 0.0, -2.0, 2.0, 3.0, 0.0] atol = 1.0e-8
 
     @testset for val in (0.0, 1.5, 4.5, 10.0)
-        @test sol(val)≈r(val) atol=1.0e-8
+        @test sol(val) ≈ r(val) atol = 1.0e-8
     end
 end
 
@@ -23,20 +23,20 @@ end
     y = r.(x)
 
     algs = [
-    # TODO: broken due to https://github.com/SciML/NonlinearSolve.jl/issues/504
-    # RationalPolynomialFitAlgorithm(2, 3),
-        RationalPolynomialFitAlgorithm(2, 3, LevenbergMarquardt())
+        # TODO: broken due to https://github.com/SciML/NonlinearSolve.jl/issues/504
+        # RationalPolynomialFitAlgorithm(2, 3),
+        RationalPolynomialFitAlgorithm(2, 3, LevenbergMarquardt()),
     ]
     u0s = [nothing, fill(10.0, 6)]
     for alg in algs, u0 in u0s
         prob = CurveFitProblem(x, y; u0 = u0)
         sol = solve(prob, alg)
 
-        @test sol.u≈[1.0, 0.0, -2.0, 2.0, 3.0, 0.0] atol=1.0e-8
+        @test sol.u ≈ [1.0, 0.0, -2.0, 2.0, 3.0, 0.0] atol = 1.0e-8
         @test SciMLBase.successful_retcode(sol.retcode)
 
         @testset for val in (0.0, 1.5, 4.5, 10.0)
-            @test sol(val)≈r(val) atol=1.0e-8
+            @test sol(val) ≈ r(val) atol = 1.0e-8
         end
     end
 end

--- a/test/stats.jl
+++ b/test/stats.jl
@@ -8,95 +8,95 @@
         # y = 2x + 1
         x = [1.0, 2.0, 3.0, 4.0, 5.0]
         y = 2.0 .* x .+ 1.0
-        
+
         prob = CurveFitProblem(x, y)
         alg = LinearCurveFitAlgorithm()
         sol = solve(prob, alg)
-        
+
         # Check coefficients (slope, intercept)
         slope, intercept = coef(sol)
-        @test slope ≈ 2.0 atol=1e-5
-        @test intercept ≈ 1.0 atol=1e-5
-        
-        @test sum(abs2, residuals(sol)) < 1e-10
-        
+        @test slope ≈ 2.0 atol = 1.0e-5
+        @test intercept ≈ 1.0 atol = 1.0e-5
+
+        @test sum(abs2, residuals(sol)) < 1.0e-10
+
         @test predict(sol) ≈ y
         @test fitted(sol) ≈ y
-        
+
         @test nobs(sol) == 5
         @test dof(sol) == 2
         @test dof_residual(sol) == 3
-        
-        @test rss(sol) < 1e-10
-        @test mse(sol) < 1e-10
-        
+
+        @test rss(sol) < 1.0e-10
+        @test mse(sol) < 1.0e-10
+
         # Check predict with array input (broadcast support)
         x_new = [1.0, 2.0]
         @test predict(sol, x_new) ≈ 2.0 .* x_new .+ 1.0
-        
+
         # Exact fit -> zero variance
-        @test all(isapprox.(vcov(sol), 0; atol=1e-8))
-        @test all(isapprox.(stderror(sol), 0; atol=1e-8))
+        @test all(isapprox.(vcov(sol), 0; atol = 1.0e-8))
+        @test all(isapprox.(stderror(sol), 0; atol = 1.0e-8))
     end
 
     @testset "Nonlinear Fit" begin
-        x = range(0, 2, length=10)
+        x = range(0, 2, length = 10)
         a_true = 1.0
         b_true = 2.0
         c_true = 0.5
         y = @. a_true + b_true * exp(c_true * x)
-        
+
         @. model(u, x) = u[1] + u[2] * exp(u[3] * x)
-        
+
         u0 = [0.5, 1.0, 0.1]
         prob = NonlinearCurveFitProblem(model, u0, x, y)
         sol = solve(prob)
-        
+
         u = coef(sol)
-        @test u[1] ≈ a_true atol=1e-2
-        @test u[2] ≈ b_true atol=1e-2
-        @test u[3] ≈ c_true atol=1e-2
-        
+        @test u[1] ≈ a_true atol = 1.0e-2
+        @test u[2] ≈ b_true atol = 1.0e-2
+        @test u[3] ≈ c_true atol = 1.0e-2
+
         @test nobs(sol) == 10
         @test dof(sol) == 3
         @test dof_residual(sol) == 7
-        
-        @test rss(sol) < 1e-4
-        
+
+        @test rss(sol) < 1.0e-4
+
         # Perfect fit -> near zero errors
-        @test all(stderror(sol) .< 1e-2)
-        
+        @test all(stderror(sol) .< 1.0e-2)
+
         @test size(vcov(sol)) == (3, 3)
     end
-    
+
     @testset "Noisy Fit Statistics" begin
         # Linear fit with noise
         x = [1.0, 2.0, 3.0, 4.0, 5.0]
         y = 2.0 .* x .+ 1.0 .+ [0.1, -0.1, 0.2, -0.2, 0.0]
-        
+
         prob = CurveFitProblem(x, y)
         alg = LinearCurveFitAlgorithm()
         sol = solve(prob, alg)
-        
+
         @test mse(sol) > 0
         @test all(stderror(sol) .> 0)
         @test size(vcov(sol)) == (2, 2)
         @test isposdef(vcov(sol))
-        
+
         # Test confidence intervals
         cis = confint(sol)
         @test length(cis) == 2
         # True params are roughly 2.0 and 1.0. CI should cover them or be close.
         # Just checking structure and non-error
         @test cis[1][1] < cis[1][2]
-        
+
         # Test isconverged
         @test isconverged(sol)
     end
-    
+
     @testset "Comprehensive API Coverage (All Types)" begin
-        x_data = collect(range(0.5, 5.0, length=20)) # Avoid 0 for log/power models
-        
+        x_data = collect(range(0.5, 5.0, length = 20)) # Avoid 0 for log/power models
+
         # 1. Log Fit: y = a + b*ln(x)
         # Truth: a=1, b=2
         y_log = @. 1.0 + 2.0 * log(x_data) + 0.01 * randn()
@@ -109,11 +109,11 @@
         # Truth: b=2, a=0.5
         y_pow = @. 2.0 * x_data^0.5 + 0.01 * randn()
         # Power fit linearizes, so y must be positive
-        prob_pow = CurveFitProblem(x_data, abs.(y_pow)) 
+        prob_pow = CurveFitProblem(x_data, abs.(y_pow))
         sol_pow = solve(prob_pow, PowerCurveFitAlgorithm())
         @test size(vcov(sol_pow)) == (2, 2)
         @test all(stderror(sol_pow) .> 0)
-        
+
         # 3. Exp Fit: y = b * exp(a*x) -> ln(y) = ln(b) + a*x
         # Truth: b=2, a=0.5
         y_exp = @. 2.0 * exp(0.5 * x_data) + 0.01 * randn()
@@ -121,32 +121,32 @@
         sol_exp = solve(prob_exp, ExpCurveFitAlgorithm())
         @test size(vcov(sol_exp)) == (2, 2)
         @test all(stderror(sol_exp) .> 0)
-        
-        # 4. Rational Fit (Linear): y = (p0 + p1*x)/(1 + q1*x) 
+
+        # 4. Rational Fit (Linear): y = (p0 + p1*x)/(1 + q1*x)
         # Truth: p0=1, p1=2, q1=0.5
         # y * (1 + 0.5x) = 1 + 2x
-        sol_rat = solve(prob_log, RationalPolynomialFitAlgorithm(num_degree=1, den_degree=1))
+        sol_rat = solve(prob_log, RationalPolynomialFitAlgorithm(num_degree = 1, den_degree = 1))
         # Params: p0, p1, q1 (3 params)
         @test size(vcov(sol_rat)) == (3, 3)
         @test all(stderror(sol_rat) .> 0)
     end
-    
+
     @testset "Explcit API Coverage (ExpSum)" begin
         # Test ExpSumFitAlgorithm explicitly to ensure jacobian works
         # y = k + p*exp(lam*x)
         # Truth: k=1, p=2, lam=-0.5
-        x_data = collect(range(0, 5, length=20))
+        x_data = collect(range(0, 5, length = 20))
         y_data = @. 1.0 + 2.0 * exp(-0.5 * x_data) + 0.01 * randn()
-        
+
         prob = CurveFitProblem(x_data, y_data)
-        sol = solve(prob, ExpSumFitAlgorithm(; n=1, withconst=true))
-        
+        sol = solve(prob, ExpSumFitAlgorithm(; n = 1, withconst = true))
+
         @test size(vcov(sol)) == (3, 3) # k, p, lam
         @test all(stderror(sol) .> 0)
 
         # Modified King Fit (E^2 = A + B * U^n)
         # x corresponds to E (Voltage) in Jacobian logic, but input data order is (U, E^2)?
-        # User creates CurveFitProblem(x, y). 
+        # User creates CurveFitProblem(x, y).
         # King assumes (Voltage, Velocity).
         # My implementation: x=E, y=U in Jacobian.
         # But in verify script I passed (U, E^2).
@@ -156,41 +156,41 @@
         y_k = @. A_true + B_true * x_k^n_true
         prob_mod_king = CurveFitProblem(x_k, y_k)
         sol_mod_king = solve(prob_mod_king, ModifiedKingCurveFitAlgorithm())
-        
+
         @test size(vcov(sol_mod_king)) == (3, 3)
         @test all(stderror(sol_mod_king) .> 0)
     end
 
-    
+
     @testset "Polynomial Fit Array Support" begin
         # Use overdetermined system (5 points, 3 params) to avoid division by zero in MSE
         x = [1.0, 2.0, 3.0, 4.0, 5.0]
-        y = x.^2
+        y = x .^ 2
         # y = 0 + 0x + 1x^2
         prob = CurveFitProblem(x, y)
         sol = solve(prob, PolynomialFitAlgorithm(2))
-        
-        @test sol.u[1] ≈ 0.0 atol=1e-5
-        @test sol.u[2] ≈ 0.0 atol=1e-5
-        @test sol.u[3] ≈ 1.0 atol=1e-5
-        
+
+        @test sol.u[1] ≈ 0.0 atol = 1.0e-5
+        @test sol.u[2] ≈ 0.0 atol = 1.0e-5
+        @test sol.u[3] ≈ 1.0 atol = 1.0e-5
+
         @test predict(sol, [2.0, 3.0]) ≈ [4.0, 9.0]
-        
-        @test size(vcov(sol)) == (3, 3) 
+
+        @test size(vcov(sol)) == (3, 3)
         @test all(stderror(sol) .>= 0)
     end
-    
+
     @testset "Interface & Solver Options" begin
         # 1. In-place evaluation (Issue #47)
         x_ip = [1.0, 2.0, 3.0]
         y_ip = [2.0, 4.0, 6.0]
-        
+
         function model_inplace!(resid, u, x)
-             # y = u[1]*x
-             # The solver expects predictions in `resid`
-             @. resid = u[1] * x
+            # y = u[1]*x
+            # The solver expects predictions in `resid`
+            @. resid = u[1] * x
         end
-        
+
         prob_ip = NonlinearCurveFitProblem(
             NonlinearFunction{true}(model_inplace!; resid_prototype = similar(y_ip)),
             [1.0], # u0
@@ -200,17 +200,17 @@
         sol_ip = solve(prob_ip)
         @test sol_ip.u[1] ≈ 2.0
         @test isconverged(sol_ip)
-        
+
         # 2. LinearSolve algorithm choices (Issue #49)
         x_ls = collect(1.0:5.0) # Use Float64 to avoid InexactError in QR
         y_ls = 2.0 .* x_ls .+ 1.0
-        
+
         # Pass LinearSolve.QRFactorization explicitly
         prob_ls = CurveFitProblem(x_ls, y_ls)
-        algo_ls = PolynomialFitAlgorithm(; degree=1, linsolve_algorithm=LinearSolve.QRFactorization())
+        algo_ls = PolynomialFitAlgorithm(; degree = 1, linsolve_algorithm = LinearSolve.QRFactorization())
         sol_ls = solve(prob_ls, algo_ls)
-        
-    
+
+
         @test sol_ls.u[1] ≈ 1.0 # intercept
         @test sol_ls.u[2] ≈ 2.0 # slope
         @test size(vcov(sol_ls)) == (2, 2)
@@ -221,50 +221,50 @@
         y_nl_ls = @. 1.0 + 2.0 * exp(-0.5 * x_nl_ls)
         @. model_nl_ls(u, x) = u[1] + u[2] * exp(u[3] * x)
         prob_nl_ls = NonlinearCurveFitProblem(model_nl_ls, [0.5, 0.5, -0.1], x_nl_ls, y_nl_ls)
-        
+
         # Test Cholesky (fast but requires PD, usually OK for LM)
-        sol_lm_chol = solve(prob_nl_ls, LevenbergMarquardt(linsolve=LinearSolve.CholeskyFactorization()))
-        @test sol_lm_chol.u[1] ≈ 1.0 atol=1e-3
+        sol_lm_chol = solve(prob_nl_ls, LevenbergMarquardt(linsolve = LinearSolve.CholeskyFactorization()))
+        @test sol_lm_chol.u[1] ≈ 1.0 atol = 1.0e-3
         @test size(vcov(sol_lm_chol)) == (3, 3)
     end
-    
+
     @testset "Extended Algorithm Test Coverage" begin
         x_data = collect(1.0:0.5:5.0)
         y_data = 2.0 .* x_data .^ 0.5 .+ 0.1
-        
+
         # 1. King Fit (Linear alias)
-        # y = A + B*sqrt(x) -> Linear fit with yfun=sqrt? No, King is xfun=abs2, yfun=sqrt? 
+        # y = A + B*sqrt(x) -> Linear fit with yfun=sqrt? No, King is xfun=abs2, yfun=sqrt?
         # Wait, King is LinearCurveFitAlgorithm(; xfun = abs2, yfun = sqrt)
         # Check source: KingCurveFitAlgorithm() = LinearCurveFitAlgorithm(; xfun = abs2, yfun = sqrt)
-        # This implies sqrt(y) = A + B*x^2. 
+        # This implies sqrt(y) = A + B*x^2.
         # This is strictly linear in transformed space, so vcov should work.
         prob_king = CurveFitProblem(x_data, y_data)
         sol_king = solve(prob_king, KingCurveFitAlgorithm())
         @test size(vcov(sol_king)) == (2, 2)
-        
+
         # 2. Rational Fit (Nonlinear)
         # Default defaults linear?
         # Providing u0 forces nonlinear path if alg is generic?
         # The struct default alg is QR/Linear?
         # RationalPolynomialFitAlgorithm(; alg=AbstractLinearAlgorithm, ...)
-        
+
         # Let's force nonlinear by providing u0 or using a nonlinear solver?
         # init(...; u0) is not supported for linear path?
         # src/rationalfit.jl: if alg.alg isa AbstractLinearAlgorithm ... @assert prob.u0 === nothing
-        
+
         # So to test nonlinear vcov for rational, we must use a nonlinear solver for `alg`.
         # RationalPolynomialFitAlgorithm(alg=LevenbergMarquardt(), ...)
         # Assuming LevenbergMarquardt is available from NonlinearSolve?
         # Or generic NewtonRaphson?
-        
+
         prob_rat_nl = CurveFitProblem(x_data, y_data) # u0 is optional in CurveFitProblem but required for Nonlinear
         # Wait, RationalPolynomialFitAlgorithm automatically generates u0 if not provided in nonlinear path?
         # src/rationalfit.jl:111: u0 = if cache.initial_guess_cache ... else cache.prob.u0
         # And it uses a linear fit for initial guess!
-        
+
         # So if we pass a nonlinear algorithm to RationalPolynomialFitAlgorithm, it should stay in nonlinear mode.
-        sol_rat_nl = solve(prob_rat_nl, RationalPolynomialFitAlgorithm(; alg=NewtonRaphson(), num_degree=1, den_degree=1))
-        
+        sol_rat_nl = solve(prob_rat_nl, RationalPolynomialFitAlgorithm(; alg = NewtonRaphson(), num_degree = 1, den_degree = 1))
+
         @test size(vcov(sol_rat_nl)) == (3, 3)
         @test all(stderror(sol_rat_nl) .> 0)
     end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)