### PR TITLE
Make `margin_error()` public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,9 +7,10 @@ CurrentModule = CurveFit
 This documents notable changes in CurveFit.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## [v1.4.0] - 2026-01-26
+## [v1.4.0] - 2026-01-30
 
 ### Added
+- Implemented [`margin_error()`](@ref) ([#81]).
 - Added support for standard deviation weights for linear fits ([#80]).
 
 ## [v1.3.0] - 2026-01-26

--- a/docs/src/api/solutions.md
+++ b/docs/src/api/solutions.md
@@ -28,5 +28,6 @@ rss
 isconverged
 vcov
 stderror
+margin_error
 confint
 ```

--- a/src/CurveFit.jl
+++ b/src/CurveFit.jl
@@ -48,7 +48,7 @@ export CurveFitSolution
 
 export solve, solve!, init
 
-export coef, residuals, predict, fitted, nobs, dof, dof_residual, rss, mse, vcov, stderror, confint
+export coef, residuals, predict, fitted, nobs, dof, dof_residual, rss, mse, vcov, stderror, margin_error, confint
 export isconverged
 
 end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -331,6 +331,13 @@ function StatsAPI.stderror(sol::CurveFitSolution; rtol::Real = NaN, atol::Real =
     return sqrt.(abs.(vars))
 end
 
+"""
+    margin_error(sol::CurveFitSolution, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
+
+Returns the margin of error of the fitted coefficients, computed as
+`stderror(sol) * t` where `t` is the critical value of the t-distribution for `1
+- alpha / 2`.
+"""
 function margin_error(sol::CurveFitSolution, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
     std_errors = stderror(sol; rtol = rtol, atol = atol)
     dist = TDist(dof(sol))
@@ -343,10 +350,8 @@ end
 
 Return confidence intervals for the fitted parameters.
 
-Confidence intervals are computed using [`stderror()`](@ref) internally. The
-confidence intervals are returned as a vector of `(lower, upper)` tuples,
-computed as `coef(sol) ± stderror(sol) * t` where `t` is the critical value
-of the t-distribution for the given confidence `level`.
+The confidence intervals are returned as a vector of `(lower, upper)` tuples,
+computed as `coef(sol) ± margin_error(sol)`.
 """
 function StatsAPI.confint(sol::CurveFitSolution; level = 0.95, rtol::Real = NaN, atol::Real = 0)
     margin_of_errors = margin_error(sol, 1 - level; rtol = rtol, atol = atol)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This is useful in cases where you want to store the uncertainty as one number instead of two.
