### PR TITLE
Add an overload for `ScalarModel` to operate in-place

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.5.0"
+version = "1.4.0"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,11 +7,15 @@ CurrentModule = CurveFit
 This documents notable changes in CurveFit.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## [v1.4.0] - 2026-01-30
+## [v1.4.0] - 2026-01-31
 
 ### Added
 - Implemented [`margin_error()`](@ref) ([#81]).
 - Added support for standard deviation weights for linear fits ([#80]).
+
+### Changed
+- [`ScalarModel()`](@ref)'s will now operate in-place for improved performance
+  ([#82]).
 
 ## [v1.3.0] - 2026-01-26
 

--- a/src/common_interface.jl
+++ b/src/common_interface.jl
@@ -176,6 +176,7 @@ struct ScalarModel{F}
 end
 
 # When called with array data, broadcast over the data
+(sm::ScalarModel)(out, params, x::AbstractArray) = out .= sm.f.(Ref(params), x)
 (sm::ScalarModel)(params, x::AbstractArray) = sm.f.(Ref(params), x)
 # When called with scalar data (for single-point evaluation), call directly
 (sm::ScalarModel)(params, x::Number) = sm.f(params, x)

--- a/test/nonlinfit.jl
+++ b/test/nonlinfit.jl
@@ -239,7 +239,9 @@ end
 
     # Use ScalarModel wrapper
     prob = NonlinearCurveFitProblem(ScalarModel(fn_scalar), [0.5, 0.5, 0.5], x, y)
+    @test SciMLBase.isinplace(prob.nlfunc)
     sol = solve(prob)
+    @test sol(x) isa Vector
 
     @test sol.u ≈ a0
     @test SciMLBase.successful_retcode(sol.retcode)


### PR DESCRIPTION
Also fixed the version number, which was accidentally bumped in a previous PR. Would it be possible to register a new release after this? I don't seem to have permission to do that on this repo since I can't push to branches, even though I'm a member of the org.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
