### PR TITLE
Fix support for reinit!() with AutoSpecializeCallable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -37,7 +37,7 @@ InverseFunctions = "0.1"
 LinearAlgebra = "1.10"
 LinearSolve = "3.15.0"
 Markdown = "1.10.0"
-NonlinearSolveBase = "2.15"
+NonlinearSolveBase = "2.25"
 NonlinearSolveFirstOrder = "2"
 PrecompileTools = "1"
 RecursiveArrayTools = "3.33.0, 4.0"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,12 @@ CurrentModule = CurveFit
 This documents notable changes in CurveFit.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## v[1.9.1] - 2026-04-25
+
+### Fixed
+- Fixed support for `reinit!()`'ing nonlinear fit caches when using the new
+  `AutoSpecializeCallable` wrapper from NonlinearSolve ([#98]).
+
 ## [v1.9.0] - 2026-04-24
 
 ### Added

--- a/src/nonlinfit.jl
+++ b/src/nonlinfit.jl
@@ -6,6 +6,9 @@ end
 
 SciMLBase.isinplace(::NonlinearFunctionWrapper{iip}) where {iip} = iip
 
+_unwrap_nonlinear_function(f::NonlinearFunctionWrapper) = f
+_unwrap_nonlinear_function(f::NonlinearSolveBase.AutoSpecializeCallable) = _unwrap_nonlinear_function(f.orig)
+
 # If `target` is nothing then we can completely ignore sigma
 __wrap_nonlinear_function(f::NonlinearFunction, ::Nothing, _) = f
 function __wrap_nonlinear_function(f::NonlinearFunction, target, sigma)
@@ -57,7 +60,7 @@ function SciMLBase.reinit!(cache::GenericNonlinearCurveFitCache; u0 = nothing, x
     end
 
     # Update `y` inplace
-    wrapper = cache.cache.prob.f.f
+    wrapper = _unwrap_nonlinear_function(cache.cache.prob.f.f)
     if !isnothing(y)
         copyto!(wrapper.target, y)
     end

--- a/test/nonlinfit.jl
+++ b/test/nonlinfit.jl
@@ -91,6 +91,7 @@ end
 @testitem "Nonlinear Least Squares: reinit!()" tags = [:nonlinfit] begin
     using CurveFit
     using SciMLBase
+    using NonlinearSolveBase: NonlinearSolveBase
 
     # Create an initial problem with a cache
     x = 1.0:10.0
@@ -108,6 +109,14 @@ end
     x = 11.0:20.0
     y = fn(a0, x)
 
+    CurveFit.reinit!(cache; u0 = [1.0, 1.0, 1.0], x, y)
+    @test solve!(cache).u ≈ a0 atol = 1.0e-7
+
+    # Repeat with an in-place model: NonlinearSolve wraps in-place Float64
+    # problems in `AutoSpecializeCallable`, which `reinit!` must unwrap.
+    fn(resid, a, x) = @. resid = a[1] + a[2] * x^a[3]
+    cache = CurveFit.init(NonlinearCurveFitProblem(fn, [0.5, 0.5, 0.5], x, y))
+    @test cache.cache.prob.f.f isa NonlinearSolveBase.AutoSpecializeCallable
     CurveFit.reinit!(cache; u0 = [1.0, 1.0, 1.0], x, y)
     @test solve!(cache).u ≈ a0 atol = 1.0e-7
 end


### PR DESCRIPTION
This previously gave a `FieldError` with a terrifyingly long type.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API