### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,28 +21,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - "All"
-          - "nopre"
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        exclude:
-          # Don't run nopre tests on pre-release Julia
-          - group: "nopre"
-            version: "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,13 @@
+# Root test-group matrix for CurveFit.jl, consumed by the reusable
+# grouped-tests.yml workflow via scripts/compute_affected_sublibraries.jl
+# --root-matrix. runtests.jl reads the GROUP env var and dispatches via
+# TestItemRunner tags: "All" runs everything except :nopre-tagged items,
+# "nopre" runs only :nopre-tagged items.
+
+[All]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macOS-latest", "windows-latest"]
+
+[nopre]
+versions = ["1", "lts"]
+os = ["ubuntu-latest", "macOS-latest", "windows-latest"]


### PR DESCRIPTION
## Summary

Converts the root test workflow (`ci.yml`, `name: CI`, job `Tests`) from a hand-maintained `group × version × os` matrix that called `tests.yml@v1` into a thin caller of the canonical `grouped-tests.yml@v1`. The test matrix now lives once in a **root `test/test_groups.toml`** and is computed by `compute_affected_sublibraries.jl --root-matrix`.

The new `jobs.tests`:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

No `with:` inputs are needed: the old job set no non-defaults (no `check-bounds`, coverage on, default `src,ext` coverage dirs, no apt packages), and `runtests.jl` reads the default `GROUP` env var.

`on:` triggers and `concurrency:` are preserved **verbatim**, and `name: CI` is kept so the branch-protection status check name is unchanged. No other workflow files were touched.

## test/test_groups.toml

```toml
[All]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macOS-latest", "windows-latest"]

[nopre]
versions = ["1", "lts"]
os = ["ubuntu-latest", "macOS-latest", "windows-latest"]
```

This reproduces the old matrix exactly: `All` on {1, lts, pre} and `nopre` on {1, lts} (the old `nopre × pre` exclude), each across the three OSes. `runtests.jl` already dispatches on `GROUP` via TestItemRunner tags (`All` = everything except `:nopre`-tagged items, `nopre` = only `:nopre`-tagged items), so **no `runtests.jl` change** is needed.

## Matrix match

Verified with `julia scripts/compute_affected_sublibraries.jl <repo> --root-matrix` against the v1 `SciML/.github` script: the emitted `(group, version, os)` set is **15/15 exact** vs the old workflow's expanded matrix. TOML and YAML both parse cleanly.

## QA

Category A — the repo already has Aqua + ExplicitImports QA test items (`test/qa.jl`, tagged `:qa`), which run inside the existing `All`/`nopre` groups. No QA changes, no source bugs surfaced; static matrix-verify only.

Ignore until reviewed by @ChrisRackauckas.