### PR TITLE
Fix Exp/Power fit docs to match returned log-space intercept (closes #110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ CurveFit.jl provides the following fitting algorithms:
 
 - **Linear fitting**: `LinearCurveFitAlgorithm` - General linear fits with customizable transformations
 - **Log fitting**: `LogCurveFitAlgorithm` - Fits `y = a*log(x) + b`
-- **Power fitting**: `PowerCurveFitAlgorithm` - Fits `y = b*x^a`
-- **Exponential fitting**: `ExpCurveFitAlgorithm` - Fits `y = b*exp(a*x)`
+- **Power fitting**: `PowerCurveFitAlgorithm` - Fits `y = exp(a*log(x) + b)` (returns `(a, b)`; scale factor is `exp(b)`)
+- **Exponential fitting**: `ExpCurveFitAlgorithm` - Fits `y = exp(a*x + b)` (returns `(a, b)`; scale factor is `exp(b)`)
 - **Polynomial fitting**: `PolynomialFitAlgorithm` - Fits polynomials of arbitrary degree
 - **Rational polynomial fitting**: `RationalPolynomialFitAlgorithm` - Fits rational functions p(x)/q(x)
 - **Sum of exponentials**: `ExpSumFitAlgorithm` - Fits `y = k + p1*exp(λ1*t) + p2*exp(λ2*t) + ...`

--- a/docs/src/tutorials/getting_started.md
+++ b/docs/src/tutorials/getting_started.md
@@ -112,7 +112,10 @@ println("Prediction at x=5: ", sol(5.0))
 
 ## Exponential Fitting
 
-Fit an exponential function `y = b * exp(a * x)`:
+Fit an exponential function `y = exp(a * x + b)`. The fit is performed in
+log-linear space, so `sol.u = (a, b)` returns the log-space intercept `b`; the
+multiplicative scale factor of the equivalent form `y = B * exp(a * x)` is
+`B = exp(b)`:
 
 ```@example exponential
 using CurveFit
@@ -132,7 +135,10 @@ println("Scale factor (b): ", exp(sol.u[2]))
 
 ## Power Law Fitting
 
-Fit a power law `y = b * x^a`:
+Fit a power law `y = exp(a * log(x) + b)`. The fit is performed in log-log
+space, so `sol.u = (a, b)` returns the log-space intercept `b`; the
+multiplicative scale factor of the equivalent form `y = B * x^a` is
+`B = exp(b)`:
 
 ```@example power
 using CurveFit

--- a/src/common_interface.jl
+++ b/src/common_interface.jl
@@ -254,14 +254,18 @@ to fit. This algorithm does not support passing weights through `sigma` in
 We want to solve for `a` and `b` such that:
 
 ```math
-y = b x^a
+y = \exp(a \log(x) + b) = \exp(b)\, x^a
 ```
 
-This is equivalent to a linear fit in log-log space, i.e.,
+This is a linear fit in log-log space, i.e.,
 
 ```math
-\log(y) = a \log(x) + \log(b)
+\log(y) = a \log(x) + b
 ```
+
+The returned parameters are `(a, b)`, where `b` is the intercept in log space.
+The multiplicative scale factor `B` of the equivalent form ``y = B x^a`` is
+recovered as ``B = \exp(b)``.
 """
 PowerCurveFitAlgorithm() = LinearCurveFitAlgorithm(; xfun = log, yfun = log)
 
@@ -274,14 +278,18 @@ fit. This algorithm does not support passing weights through `sigma` in
 We want to solve for `a` and `b` such that:
 
 ```math
-y = b \exp(a x)
+y = \exp(a x + b)
 ```
 
-This is equivalent to a linear fit in log-linear space, i.e.,
+This is a linear fit in log-linear space, i.e.,
 
 ```math
-\log(y) = a x + \log(b)
+\log(y) = a x + b
 ```
+
+The returned parameters are `(a, b)`, where `b` is the intercept in log space.
+The multiplicative scale factor `B` of the equivalent form ``y = B \exp(a x)``
+is recovered as ``B = \exp(b)``.
 """
 ExpCurveFitAlgorithm() = LinearCurveFitAlgorithm(; xfun = identity, yfun = log)
 


### PR DESCRIPTION
## Summary

Fixes #110.

`ExpCurveFitAlgorithm` and `PowerCurveFitAlgorithm` linearize in log space via `LinearCurveFitAlgorithm`, which fits `log(y) = a*f(x) + b` and returns `sol.u = (a, b)`. Here `b` is the **intercept in log space** — i.e. `log` of the multiplicative scale factor — not the scale factor itself.

The docstrings and README, however, advertised the models as `y = b*exp(a*x)` and `y = b*x^a` with `b` returned directly. That is inconsistent with the actual `(a, log(b))` output, as reported in the issue:

```julia
julia> x=[1,2,3]; y=exp.(0.2 .+ 0.3*x);
julia> solve(CurveFitProblem(x,y), ExpCurveFitAlgorithm()).u
(0.3000000000000001, 0.20000000000000048)   # u[2] = 0.2 = log-space intercept, not 2.0·…
```

The current behavior is intentional and already reflected elsewhere in the codebase:
- `docs/src/tutorials/getting_started.md` recovers the scale factor with `exp(sol.u[2])`.
- `test/linfit_exp.jl` and `test/linfit_power.jl` assert `sol.u[2] ≈ log(2.0)`.

This PR fixes only the **documentation** to match that behavior (the non-breaking resolution requested in the issue's "Expected behavior"):

- Docstrings (`ExpCurveFitAlgorithm`, `PowerCurveFitAlgorithm`): restate the models as `y = exp(a*x + b)` and `y = exp(a*log(x) + b)`, matching the linear fit `log(y) = a*f(x) + b`, and note that the scale factor of the equivalent `y = B*exp(a*x)` / `y = B*x^a` form is recovered as `B = exp(b)`.
- README: same correction for the two entries.
- Tutorial prose: clarify the log-space convention (the code blocks were already correct).

## Why docs and not code

The returned-parameter semantics are part of the v1 public API and are already pinned by the existing test assertions (`sol.u[2] ≈ log(2.0)`) and the tutorial's `exp(sol.u[2])`. Changing the returned values to the multiplicative form would be a breaking change and would also complicate the generic `LinearCurveFitAlgorithm` abstraction (which returns the raw log-space intercept for any `yfun`). The issue's stated expected behavior is the documentation fix.

## Testing

The behavior is already covered by `test/linfit_exp.jl` and `test/linfit_power.jl`, both of which assert `sol.u[2] ≈ log(2.0)`. Ran both locally — 7/7 pass each. Runic reports no changes needed on `src/common_interface.jl`.

---

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)