### PR TITLE
Copy nonlinear fit input arrays into the cache struct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.10.1"
+version = "1.11.0"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -40,7 +40,7 @@ NonlinearSolveFirstOrder = "2"
 PrecompileTools = "1.1"
 RecursiveArrayTools = "3.33.0, 4.0"
 SafeTestsets = "0.1"
-SciMLBase = "2.90, 3.27"
+SciMLBase = "3.32"
 SciMLTesting = "1.7"
 Setfield = "1.1.2"
 StatsAPI = "1.8.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 CurveFit = "5a033b19-8c74-5913-a970-47c3779ef25c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 
 [sources]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 import Changelog
 using Documenter
+using DocumenterInterLinks
 using CurveFit
 using CommonSolve
 using NonlinearSolve: NonlinearSolve
@@ -21,6 +22,10 @@ Changelog.generate(
     repo = "SciML/CurveFit.jl"
 )
 
+links = InterLinks(
+    "SciMLBase" => "https://docs.sciml.ai/SciMLBase/stable/"
+)
+
 makedocs(;
     sitename = "CurveFit.jl",
     authors = "CurveFit Contributors",
@@ -33,7 +38,8 @@ makedocs(;
         canonical = "https://docs.sciml.ai/CurveFit/stable/",
         assets = String[],
     ),
-    pages = pages
+    pages = pages,
+    plugins = [links]
 )
 
 deploydocs(;

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,19 @@ CurrentModule = CurveFit
 This documents notable changes in CurveFit.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.11.0] - 2026-07-08
+
+### Added
+- Implemented [`CurveFitAliasSpecifier`](@ref) so that it's possible to specify
+  which arrays are aliased or copied when creating a [`CurveFitProblem`](@ref)
+  ([#117]).
+
+### Fixed
+- Changed the solver for [`NonlinearCurveFitProblem`](@ref) to (by default) make
+  copies of the input arrays into its internal cache so that the original input
+  arrays won't be overwritten if `reinit!(cache; x, y, sigma)` is called
+  ([#117]). This can be controlled with [`CurveFitAliasSpecifier`](@ref)
+
 ## [v1.10.1] - 2026-07-01
 
 ### Fixed

--- a/docs/src/api/problems.md
+++ b/docs/src/api/problems.md
@@ -29,3 +29,13 @@ type that allows defining scalar models.
 ```@docs
 ScalarModel
 ```
+
+## Aliasing
+For the sake of performance it's sometimes desirable to allow aliasing input
+arrays rather than making copies of them. The solvers in CurveFit.jl attempt to
+make reasonable defaults, but it's possible to customize the aliasing defaults
+with [`CurveFitAliasSpecifier`](@ref).
+
+```@docs
+CurveFitAliasSpecifier
+```

--- a/src/CurveFit.jl
+++ b/src/CurveFit.jl
@@ -36,7 +36,7 @@ include("expsumfit.jl")
 include("stats.jl")
 
 # Exported functions
-export CurveFitProblem, NonlinearCurveFitProblem, ScalarModel
+export CurveFitProblem, NonlinearCurveFitProblem, ScalarModel, CurveFitAliasSpecifier
 
 export LinearCurveFitAlgorithm, LogCurveFitAlgorithm, PowerCurveFitAlgorithm,
     ExpCurveFitAlgorithm, PolynomialFitAlgorithm

--- a/src/common_interface.jl
+++ b/src/common_interface.jl
@@ -458,6 +458,20 @@ end
 Represents the solution to a curve fitting problem. This is a callable struct and
 can be used to evaluate the solution at a point. Exact evaluation mechanism depends on the
 algorithm used to solve the problem.
+
+!!! note "Aliasing semantics"
+    The `x`/`y`/`sigma` arrays in `sol.prob` alias the solver cache's internal
+    arrays rather than copies of them. For nonlinear fits those internal arrays
+    are, by default, copies of the problems input arrays. A subsequent `reinit!`
+    of the cache mutates them in place, so a solution returned beforehand will
+    reflect the new data. Copy the `sol.prob` fields if you need a stable
+    snapshot.
+
+    Whether the cache aliases or copies the input `x`/`y`/`sigma`/`u0` arrays can
+    be controlled by passing a [`CurveFitAliasSpecifier`](@ref) as the `alias`
+    keyword to `init`/`solve`. By default `x`/`y`/`sigma` are aliased and `u0` is
+    copied for the linear fits, while the nonlinear fits copy all of them so that
+    `reinit!` doesn't overwrite the users input.
 """
 @concrete struct CurveFitSolution <: AbstractCurveFitSolution
     alg <: AbstractCurveFitAlgorithm
@@ -489,6 +503,68 @@ function Base.show(io::IO, ::MIME"text/plain", sol::CurveFitSolution)
 end
 
 SciMLBase.successful_retcode(sol::CurveFitSolution) = SciMLBase.successful_retcode(sol.retcode)
+
+
+"""
+    CurveFitAliasSpecifier(; alias_x = nothing, alias_y = nothing, alias_sigma = nothing, alias_u0 = nothing, alias = nothing)
+
+Holds information on what variables to alias when solving a curve fit problem.
+Conforms to the [`SciMLBase.AbstractAliasSpecifier`](@extref) interface.
+
+When a keyword argument is `nothing`, the default behaviour is used.
+
+### Keywords
+
+* `alias_x::Union{Bool, Nothing}`: alias the `x` array.
+* `alias_y::Union{Bool, Nothing}`: alias the `y` array.
+* `alias_sigma::Union{Bool, Nothing}`: alias the `sigma` array.
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
+* `alias::Union{Bool, Nothing}`: sets all fields of the `CurveFitAliasSpecifier` to `alias`.
+"""
+struct CurveFitAliasSpecifier <: SciMLBase.AbstractAliasSpecifier
+    alias_x::Union{Bool, Nothing}
+    alias_y::Union{Bool, Nothing}
+    alias_sigma::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+
+    function CurveFitAliasSpecifier(;
+            alias_x = nothing, alias_y = nothing,
+            alias_sigma = nothing, alias_u0 = nothing,
+            alias = nothing
+        )
+        return if isnothing(alias)
+            new(alias_x, alias_y, alias_sigma, alias_u0)
+        elseif alias
+            new(true, true, true, true)
+        elseif !alias
+            new(false, false, false, false)
+        end
+    end
+end
+
+_maybe_alias(::Nothing, ::Union{Bool, Nothing}, ::Bool) = nothing
+
+function _maybe_alias(x::AbstractArray, flag::Union{Bool, Nothing}, default::Bool)
+    return @something(flag, default) ? x : copyto!(similar(x), x)
+end
+
+# Return a `CurveFitProblem` whose input arrays are aliased or copied according
+# to `alias` (falling back to `default_*` when `alias = nothing`).
+function _alias_inputs(
+        prob::CurveFitProblem, alias::CurveFitAliasSpecifier;
+        default_x::Bool = true, default_y::Bool = true,
+        default_sigma::Bool = true, default_u0::Bool = false
+    )
+    return CurveFitProblem(
+        _maybe_alias(prob.x, alias.alias_x, default_x),
+        _maybe_alias(prob.y, alias.alias_y, default_y),
+        _maybe_alias(prob.sigma, alias.alias_sigma, default_sigma),
+        prob.nlfunc,
+        _maybe_alias(prob.u0, alias.alias_u0, default_u0),
+        prob.lb,
+        prob.ub
+    )
+end
 
 # Common Solve Interface
 """

--- a/src/expsumfit.jl
+++ b/src/expsumfit.jl
@@ -150,13 +150,15 @@ end
 end
 
 function CommonSolve.init(
-        prob::CurveFitProblem, alg::ExpSumFitAlgorithm; kwargs...
+        prob::CurveFitProblem, alg::ExpSumFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
     )
     @assert !is_nonlinear_problem(prob) "Exponential sum fitting only works with linear \
                                          problems"
     sigma_not_supported(prob)
     bounds_not_supported(prob)
 
+    prob = _alias_inputs(prob, alias)
     T = eltype(prob.x)
 
     len = length(prob.x)

--- a/src/king.jl
+++ b/src/king.jl
@@ -12,11 +12,15 @@ end
     kwargs
 end
 
-function CommonSolve.init(prob::CurveFitProblem, alg::KingCurveFitAlgorithm; kwargs...)
+function CommonSolve.init(
+        prob::CurveFitProblem, alg::KingCurveFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
+    )
     @assert !is_nonlinear_problem(prob) "King's law fitting doesn't work with nlfunc specification."
     @assert prob.u0 === nothing "King's law fit doesn't support initial guess (u0) specification"
     sigma_not_supported(prob)
     bounds_not_supported(prob)
+    prob = _alias_inputs(prob, alias)
     return KingFitCache(prob, alg, kwargs)
 end
 
@@ -45,12 +49,14 @@ end
 end
 
 function CommonSolve.init(
-        prob::CurveFitProblem, alg::ModifiedKingCurveFitAlgorithm; kwargs...
+        prob::CurveFitProblem, alg::ModifiedKingCurveFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
     )
     @assert !is_nonlinear_problem(prob) "Modified King's law fitting doesn't work with \
                                          nlfunc specification."
     sigma_not_supported(prob)
 
+    prob = _alias_inputs(prob, alias)
     initial_guess_cache = if prob.u0 !== nothing
         nothing
     else

--- a/src/linfit.jl
+++ b/src/linfit.jl
@@ -41,7 +41,10 @@ end
     alg <: LinearCurveFitAlgorithm
 end
 
-function CommonSolve.init(prob::CurveFitProblem, alg::LinearCurveFitAlgorithm; kwargs...)
+function CommonSolve.init(
+        prob::CurveFitProblem, alg::LinearCurveFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
+    )
     @assert !is_nonlinear_problem(prob) "Linear curve fitting only works with linear \
                                          problems"
     @assert prob.u0 === nothing "Linear fit doesn't support initial guess (u0) \
@@ -50,6 +53,7 @@ function CommonSolve.init(prob::CurveFitProblem, alg::LinearCurveFitAlgorithm; k
         supported when yfun ≠ identity (e.g., PowerCurveFitAlgorithm, ExpCurveFitAlgorithm)"
     bounds_not_supported(prob)
 
+    prob = _alias_inputs(prob, alias)
     return GenericLinearFitCache(prob, kwargs, alg)
 end
 
@@ -86,7 +90,8 @@ end
 end
 
 function CommonSolve.init(
-        prob::CurveFitProblem, alg::PolynomialFitAlgorithm; kwargs...
+        prob::CurveFitProblem, alg::PolynomialFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
     )
     @assert !is_nonlinear_problem(prob) "Linear curve fitting only works with linear \
                                          problems"
@@ -95,6 +100,7 @@ function CommonSolve.init(
     sigma_not_supported(prob)
     bounds_not_supported(prob)
 
+    prob = _alias_inputs(prob, alias)
     vandermondepoly_cache = similar(prob.x, length(prob.x), alg.degree + 1)
     linsolve_cache = init(
         LinearProblem(vandermondepoly_cache, prob.y), alg.linsolve_algorithm; kwargs...

--- a/src/nonlinfit.jl
+++ b/src/nonlinfit.jl
@@ -6,11 +6,6 @@ end
 
 SciMLBase.isinplace(::NonlinearFunctionWrapper{iip}) where {iip} = iip
 
-_unwrap_nonlinear_function(f::NonlinearFunctionWrapper) = f
-_unwrap_nonlinear_function(f::NonlinearSolveBase.AutoSpecializeCallable) = _unwrap_nonlinear_function(f.orig)
-_unwrap_nonlinear_function(f::NonlinearSolveBase.BoundedWrapper) = _unwrap_nonlinear_function(f.f.f)
-_unwrap_nonlinear_function(f) = f
-
 __wrap_nonlinear_function(f::NonlinearFunction, ::Nothing, ::Nothing) = f
 function __wrap_nonlinear_function(f::NonlinearFunction, target, sigma)
     internal_f = NonlinearFunctionWrapper{SciMLBase.isinplace(f)}(target, sigma, f.f)
@@ -54,6 +49,9 @@ end
 @concrete struct GenericNonlinearCurveFitCache <: AbstractCurveFitCache
     prob <: CurveFitProblem
     cache
+    x <: AbstractArray
+    y <: Union{AbstractArray, Nothing}
+    sigma <: Union{AbstractArray, Nothing}
     u0
     alg
     kwargs
@@ -68,23 +66,23 @@ function SciMLBase.reinit!(cache::GenericNonlinearCurveFitCache; u0 = nothing, x
 
     # x becomes `p` (parameter) in the NonlinearLeastSquaresProblem
     if !isnothing(x)
-        @assert size(x) == size(_get_cache(cache).p) "reiniting `x` must keep the same size"
-        kwargs = (; kwargs..., p = x)
+        @assert size(x) == size(cache.x) "reiniting `x` must keep the same size"
+        copyto!(cache.x, x)
+        kwargs = (; kwargs..., p = cache.x)
     end
 
     # Update `y` inplace
-    wrapper = _unwrap_nonlinear_function(cache.cache.prob.f.f)
     if !isnothing(y)
-        @assert wrapper isa NonlinearFunctionWrapper && !isnothing(wrapper.target) "cannot reinit `y` for a problem created without a `y`"
-        @assert size(y) == size(wrapper.target) "reiniting `y` must keep the same size"
-        copyto!(wrapper.target, y)
+        @assert !isnothing(cache.y) "cannot reinit `y` for a problem created without a `y`"
+        @assert size(y) == size(cache.y) "reiniting `y` must keep the same size"
+        copyto!(cache.y, y)
     end
 
     # Update `sigma` inplace
     if !isnothing(sigma)
-        @assert wrapper isa NonlinearFunctionWrapper && !isnothing(wrapper.sigma) "cannot reinit `sigma` for a problem created without a `sigma`"
-        @assert size(sigma) == size(wrapper.sigma) "reiniting `sigma` must keep the same size"
-        copyto!(wrapper.sigma, sigma)
+        @assert !isnothing(cache.sigma) "cannot reinit `sigma` for a problem created without a `sigma`"
+        @assert size(sigma) == size(cache.sigma) "reiniting `sigma` must keep the same size"
+        copyto!(cache.sigma, sigma)
     end
 
     reinit!(cache.cache; kwargs...)
@@ -93,11 +91,18 @@ function SciMLBase.reinit!(cache::GenericNonlinearCurveFitCache; u0 = nothing, x
 end
 
 function CommonSolve.init(
-        prob::CurveFitProblem, alg::__FallbackNonlinearFitAlgorithm; kwargs...
+        prob::CurveFitProblem, alg::__FallbackNonlinearFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
     )
     @assert is_nonlinear_problem(prob) "Nonlinear curve fitting only works with nonlinear \
                                         problems"
     @assert prob.u0 !== nothing "Nonlinear curve fitting requires an initial guess (u0)"
+
+    # By default the input arrays are copied into the cache so that reinit!'ing
+    # the cache (which mutates them in place) doesn't overwrite the user's data.
+    prob = _alias_inputs(
+        prob, alias; default_x = false, default_y = false, default_sigma = false
+    )
 
     return GenericNonlinearCurveFitCache(
         prob,
@@ -109,36 +114,28 @@ function CommonSolve.init(
             alg.alg;
             kwargs...
         ),
-        copy(prob.u0),
+        prob.x,
+        prob.y,
+        prob.sigma,
+        prob.u0,
         alg,
         kwargs
     )
 end
 
 function CommonSolve.solve!(cache::GenericNonlinearCurveFitCache)
-    inner = _get_cache(cache)
-    x = inner.p
     sol = solve!(cache.cache)
 
-    y = cache.prob.y
-    sigma = cache.prob.sigma
-
-    wrapped_f = _unwrap_nonlinear_function(inner.prob.f.f)
-    if wrapped_f isa NonlinearFunctionWrapper
-        y = wrapped_f.target
-        sigma = wrapped_f.sigma
-    end
-
-    # Reconstruct the problem with the current settings. We can't copy
+    # Reconstruct the problem with the current settings. We can't use
     # cache.prob because the cache may have been reinit()'d in which case
     # cache.prob will be out of date and will give wrong results for the stats
     # functions that use it.
     prob = CurveFitProblem(
-        x,
-        y,
-        sigma,
+        cache.x,
+        cache.y,
+        cache.sigma,
         cache.prob.nlfunc,
-        cache.u0,
+        copy(cache.u0),
         cache.prob.lb,
         cache.prob.ub
     )

--- a/src/rationalfit.jl
+++ b/src/rationalfit.jl
@@ -54,12 +54,14 @@ end
 end
 
 function CommonSolve.init(
-        prob::CurveFitProblem, alg::RationalPolynomialFitAlgorithm; kwargs...
+        prob::CurveFitProblem, alg::RationalPolynomialFitAlgorithm;
+        alias::CurveFitAliasSpecifier = CurveFitAliasSpecifier(), kwargs...
     )
     @assert !is_nonlinear_problem(prob) "Rational polynomial fitting doesn't work with \
                                          nlfunc specification."
     sigma_not_supported(prob)
 
+    prob = _alias_inputs(prob, alias)
     coeffs_length = alg.num_degree + alg.den_degree + 1
 
     if alg.alg isa AbstractLinearAlgorithm

--- a/test/nonlinfit_reinit.jl
+++ b/test/nonlinfit_reinit.jl
@@ -67,4 +67,16 @@ using NonlinearSolveBase: NonlinearSolveBase
 
     cache = CurveFit.init(NonlinearCurveFitProblem(g, [0.5, 0.5, 0.5], x))
     @test_throws AssertionError CurveFit.reinit!(cache; y)
+
+    # reinit!() must not modify the user-provided arrays
+    x = collect(1.0:10.0)
+    y = g([3.0, 2.0, 0.7], x)
+    sigma = ones(length(y))
+    x_orig, y_orig, sigma_orig = copy(x), copy(y), copy(sigma)
+    cache = CurveFit.init(NonlinearCurveFitProblem(g, [0.5, 0.5, 0.5], x, y, sigma))
+    sol = solve!(cache)
+    CurveFit.reinit!(cache; x = x .+ 1, y = y .+ 1, sigma = sigma .+ 1)
+    @test x == x_orig
+    @test y == y_orig
+    @test sigma == sigma_orig
 end


### PR DESCRIPTION
So that we don't accidentally overwrite the input when using the caches directly and calling `reinit!()` on them.

Note that the code already makes a copy of `u` when creating the solution, so that's not aliased. I considered making that aliasing as well but decided it would be too confusing since I could definitely see situations where people call `reinit!()` + `solve!()` in a loop and push `u` to an array or something.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API