### PR TITLE
Release prep: bump CurveFit to 1.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.11.0"
+version = "1.11.1"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test compat changes (SciMLTesting test-only compat floor bump) since 1.11.0; no functional/runtime changes.