### PR TITLE
Release prep: bump version to 1.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CurveFit"
 uuid = "5a033b19-8c74-5913-a970-47c3779ef25c"
-version = "1.11.1"
+version = "1.11.2"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com>, Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps `version` in Project.toml from 1.11.1 to 1.11.2. The last registered version (1.11.1, PR #120 / commit `cecadca`) matches the General registry tree-sha1 exactly (`cfd1799b89b266b3925553fdc2d1a0fd0cad9372`).

Since that commit, only one commit has landed on `master`:

- #121 "Drop CurveFit QA self source" — removes a `[sources]` self-path override (`CurveFit = {path = "../.."}`) from `test/qa/Project.toml`. This is a test/QA-config-only change; no source files, public API, or main `Project.toml` `[compat]` bounds are touched.

## Bump type: PATCH (1.11.1 -> 1.11.2)

No new features, no breaking changes, no compat changes — this is a test-infrastructure-only diff, so PATCH is appropriate per SemVer.

## Compat bounds

Not touched. The diff since 1.11.1 doesn't modify the main `Project.toml`'s `[compat]` section and introduces no new usage of SciML-ecosystem APIs, so existing lower bounds remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)